### PR TITLE
add .gitattributes to fix code vendoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+flamingo/server/lib/* linguist-vendored

--- a/vendor.yml
+++ b/vendor.yml
@@ -1,1 +1,0 @@
-- flamingo/server/lib/


### PR DESCRIPTION
This vendors all code located in flamingo/server/lib/ to not pollute the
language statistics and erroneously report the project as being js.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>