### PR TITLE
Plugins: Add MetaParser for .meta -files

### DIFF
--- a/flamingo/plugins/__init__.py
+++ b/flamingo/plugins/__init__.py
@@ -11,3 +11,4 @@ from .html import HTML  # NOQA
 from .i18n import I18N  # NOQA
 from .tags import Tags  # NOQA
 from .time import Time  # NOQA
+from .metaFile import MetaFile  # NOQA

--- a/flamingo/plugins/metaFile.py
+++ b/flamingo/plugins/metaFile.py
@@ -1,0 +1,31 @@
+from flamingo.core.parser import ContentParser
+
+
+class MetaParser(ContentParser):
+    FILE_EXTENSIONS = ['meta']
+
+    """
+    This parser can be used to load files that do not contain a content part
+    and only contain a metadata part.
+    This can be useful if you want to generate pages just from some
+    pice of structured information and all your markup is handled in
+    the template.
+
+    Add *.meta -files to your content-directory to use this parser.
+    """
+
+    def parse(self, file_content, content):
+
+        # .meta files do not have a content part.
+        # But parse_meta_data() assumes it has one.
+        # We will add an extra \n\n\n at the end to make it useable for our
+        # usecase. We will discard the body anway.
+
+        file_content = file_content + "\n\n\n"
+
+        self.parse_meta_data(file_content, content)
+
+
+class MetaFile:
+    def parser_setup(self, context):
+        context.parser.add_parser(MetaParser(context))


### PR DESCRIPTION
This parser is intended for files that do not contain a content-part.
The parser takes the loaded file and extends it in a way, that it can
be parsed by flamingo's parse_meta_data().

I have not activated this plugin by default. It is pretty useful for my
use case. But I am quite sure that this is not an 80% use case.

Signed-off-by: Chris Fiege <chris@tinyhost.de>