### PR TITLE
core: make --version work

### DIFF
--- a/flamingo/core/utils/cli.py
+++ b/flamingo/core/utils/cli.py
@@ -37,6 +37,7 @@ def get_raw_parser(*parser_args, description='', **parser_kwargs):
     parser = ArgumentParser(*parser_args, description=description,
                             formatter_class=RawTextHelpFormatter,
                             **parser_kwargs)
+    parser.add_argument('--version', action='version', version=VERSION)
 
     return parser
 


### PR DESCRIPTION
`--version` is supported by almost all Unix-like tools, so make it work here too as a consistent interface for users.