### PR TITLE
server: fix variable interpolation

### DIFF
--- a/bin/_flamingo-server
+++ b/bin/_flamingo-server
@@ -273,7 +273,7 @@ app.router.add_route('*', '/live-server/', index)
 app.router.add_route('*', '/{path_info:.*}', exporter)
 
 # run
-print('starting server on http://localhost:{}/live-server/'.format(
+print('starting server on http://{}:{}/live-server/'.format(
     namespace.host, namespace.port))
 
 try:


### PR DESCRIPTION
Currently, the server prints something like

```
starting server on http://localhost:localhost/live-server/
```

which will not open coreectly in a browser. Replace `localhost` with the host name from the configuration, so the port is then also interpolated correctly as the second parameter.