### PR TITLE
core/layers: Check if directories exist before use

### DIFF
--- a/flamingo/core/plugins/layers.py
+++ b/flamingo/core/plugins/layers.py
@@ -1,4 +1,7 @@
 import os
+import logging
+
+logger = logging.getLogger("flamingo.core.layers")
 
 
 def _cp(context, source, destination):
@@ -17,6 +20,9 @@ class PreBuildLayers:
         OUTPUT_ROOT = context.settings.OUTPUT_ROOT
 
         for layer in context.settings.PRE_BUILD_LAYERS:
+            if not os.path.exists(layer):
+                logger.error("PreBuildLayer '%s' not found.", layer)
+                continue
             _cp(context, layer, OUTPUT_ROOT)
 
 
@@ -25,4 +31,7 @@ class PostBuildLayers:
         OUTPUT_ROOT = context.settings.OUTPUT_ROOT
 
         for layer in context.settings.POST_BUILD_LAYERS:
+            if not os.path.exists(layer):
+                logger.error("PostBuildLayer '%s' not found.", layer)
+                continue
             _cp(context, layer, OUTPUT_ROOT)


### PR DESCRIPTION
PRE_BUILD_LAYERS and POST_BUILD_LAYERS are defined by the user in their
settings.
If the given layers (and so directories) do not exist this change prints
an error message instead of a stacktrace.

Signed-off-by: Chris Fiege <chris@tinyhost.de>