### PR TITLE
doc: Import correct Classes

### DIFF
--- a/doc/content/cookbook/how_to_add_a_rst_directive.rst
+++ b/doc/content/cookbook/how_to_add_a_rst_directive.rst
@@ -85,8 +85,9 @@ useful if you have more complex directives.
 
 .. code-block:: python
 
-    from docutils.parsers.rst import Directive, directives
+    from docutils.parsers.rst import directives
     from docutils.nodes import raw
+    from flamingo.plugins.rst.base import NestedDirective
 
 
     def div(context):


### PR DESCRIPTION
The previous examples import `docutil.parsers.Directive` what is
actually used there.

In the inline-rst-example a parser form `flamingo.plugins.rst.base` is
used. Thus this commit changes the import to the correct class.

Signed-off-by: Chris Fiege <chris@tinyhost.de>