### PR TITLE
Typos

### DIFF
--- a/doc/content/cookbook/how_to_write_a_plugin.rst
+++ b/doc/content/cookbook/how_to_write_a_plugin.rst
@@ -191,7 +191,7 @@ If you need to access the state of another plugin you can get it by using
 Media
 -----
 
-Flamingo uses the same data model for medimedia objects like for
+Flamingo uses the same data model for media objects like for
 {{ link('developer/data_model.rst', 'content objects') }}. When a media content
 gets added to a content object, it get stored in ``content['media']``.
 

--- a/doc/content/cookbook/how_to_write_a_plugin.rst
+++ b/doc/content/cookbook/how_to_write_a_plugin.rst
@@ -7,7 +7,7 @@ All flamingo plugins have to be a python class, defining hooks which are simple
 python methods.
 
 All hooks get the ``context`` object passed in. Some hooks get
-``flamingo.Content`` objects passed in. More informations on Content objects:
+``flamingo.Content`` objects passed in. More information on Content objects:
 {{ link('developer/data_model.rst', 'Flamingo data model') }}
 
 
@@ -191,7 +191,7 @@ If you need to access the state of another plugin you can get it by using
 Media
 -----
 
-Flamingo uses the same data model for content objects like for
+Flamingo uses the same data model for medimedia objects like for
 {{ link('developer/data_model.rst', 'content objects') }}. When a media content
 gets added to a content object, it get stored in ``content['media']``.
 

--- a/doc/content/index.rst
+++ b/doc/content/index.rst
@@ -84,7 +84,7 @@ Per definition, content managed with a static site generator gets written
 rarely but read often.
 
 This means long build times of multiple seconds or even up to minutes are
-totally acceptable. Flamingo is designed be to easy and reusable, not to be
+totally acceptable. Flamingo is designed to be easy and reusable, not to be
 fast! It is written in pure python and all operations run in RAM.
 
 

--- a/doc/content/user/basic_concepts.rst
+++ b/doc/content/user/basic_concepts.rst
@@ -22,7 +22,7 @@ Context
 -------
 
 The ``flamingo.core.context.Context`` object holds all runtime state, with all
-settings, loaded plugins and media informations. It gets passed into every
+settings, loaded plugins and media information. It gets passed into every
 plugin hook and is available in every rendered template and content object.
 
 In the diagram above the context is shown as violet box.

--- a/doc/content/user/settings.rst
+++ b/doc/content/user/settings.rst
@@ -4,7 +4,7 @@ Settings
 ========
 
 Flamingo manages its settings in plain python files. Settings are project
-specific and hold informations like where the content files are stored, where
+specific and hold information like where the content files are stored, where
 the output should be written to and which plugins are installed.
 
 
@@ -30,7 +30,7 @@ Overlaying Settings
 Most of flamingo command line tools come with an option ``-s`` for settings,
 which can be one or more python files.
 
-Let's say you have two settings files named ``settings.py`` und ``debug.py``.
+Let's say you have two settings files named ``settings.py`` and ``debug.py``.
 
 .. code-block:: python
 

--- a/doc/content/user/shell.rst
+++ b/doc/content/user/shell.rst
@@ -21,7 +21,7 @@ Shell
 **For this feature IPython needs to be installed. Read the
 "Optional external dependencies" section in
 {{ link('user/getting_started.rst', 'Getting started') }} for more
-informations**
+information**
 
 Flamingo supports interactive shells using ``flamingo shell`` for debugging.
 If you bootstrapped your project according to


### PR DESCRIPTION
Fixed a few typos. Information has no plural form in English (see e.g., https://de.pons.com/%C3%BCbersetzung/englisch-deutsch/information).

One fix changes the meaning of the sentence (in the "Plugin Howto"). I hope the correction is appropriate.