### PR TITLE
jinja2: contextfunction has been replaced by pass_context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 language: python
 
 stages:

--- a/flamingo/core/templating/jinja2.py
+++ b/flamingo/core/templating/jinja2.py
@@ -7,7 +7,7 @@ import code
 import html
 import os
 
-from jinja2 import Environment, FileSystemLoader, contextfunction
+from jinja2 import Environment, FileSystemLoader, pass_context
 from jinja2 import TemplateNotFound, TemplateSyntaxError
 
 from flamingo.core.templating.base import TemplatingEngine
@@ -67,7 +67,7 @@ def html_escape(obj):
     return html.escape(obj)
 
 
-@contextfunction
+@pass_context
 def _shell(context):
     if IPYTHON:
         IPython.embed()
@@ -80,7 +80,7 @@ def _import(*args, **kwargs):
     return acquire(*args, **kwargs)[0]
 
 
-@contextfunction
+@pass_context
 def link(context, path, *args, name='', lang='', i18n=True, find_name=False,
          _content_path=None, _content_lineno=None, **kwargs):
 

--- a/flamingo/pytest.py
+++ b/flamingo/pytest.py
@@ -2,6 +2,7 @@ from subprocess import check_output, CalledProcessError, STDOUT
 from tempfile import TemporaryDirectory
 import logging
 import os
+import asyncio
 
 from aiohttp.web import Application
 import pytest
@@ -109,6 +110,7 @@ class FlamingoServerBuildEnvironment(FlamingoBuildEnvironment):
         self.app = None
         self.server = None
         self.client = None
+        self.loop = asyncio.get_event_loop()
 
     def build(self, *args, **kwargs):
         pass
@@ -142,7 +144,7 @@ class FlamingoServerBuildEnvironment(FlamingoBuildEnvironment):
             return self.app
 
         self.setup()
-        self.client = await self._aiohttp_client(_create_app)
+        self.client = await self._aiohttp_client(_create_app(self.loop))
 
     async def shutdown_live_server(self, app=None):
         if self.server:

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ log_cli=false
 log_level=NOTSET
 log_format = %(levelname)-8s %(name)-30s [%(asctime)s.%(msecs)03d] %(message)s
 log_date_format = %H:%M:%S
+asyncio_mode = auto

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import flamingo
 
 INSTALL_REQUIRES = [
-    'jinja2',
+    'jinja2>=3.0.0',
     'docutils',
     'pyyaml',
     'beautifulsoup4',


### PR DESCRIPTION
Since jinja2 3.0.0, contextfunction has been replaced by pass_function.
Without this patch, a server explodes with

```
flamingo server -s settings.py menu.py --port=8080 --host=localhost
ERROR:flamingo.server:setup failed
  Traceback (most recent call last):
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/utils/imports.py", line 19, in acquire
      item = importlib.import_module(item)
    File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
    File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
    File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
    File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 790, in exec_module
    File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/templating/__init__.py", line 2, in <module>
      from .jinja2 import Jinja2  # NOQA
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/templating/jinja2.py", line 10, in <module>
      from jinja2 import Environment, FileSystemLoader, contextfunction
  ImportError: cannot import name 'contextfunction' from 'jinja2' ([...]/env-3.9.2/lib/python3.9/site-packages/jinja2/__init__.py)

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/server/server.py", line 132, in setup
      self.build_environment.setup()
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/server/build_environment.py", line 40, in setup
      self.context.setup()
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/context.py", line 47, in setup
      templating_engine_class, path = acquire(
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/utils/imports.py", line 30, in acquire
      module = importlib.import_module(module_name)
    File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
    File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 790, in exec_module
    File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/templating/__init__.py", line 2, in <module>
      from .jinja2 import Jinja2  # NOQA
    File "[...]/env-3.9.2/lib/python3.9/site-packages/flamingo/core/templating/jinja2.py", line 10, in <module>
      from jinja2 import Environment, FileSystemLoader, contextfunction
  ImportError: cannot import name 'contextfunction' from 'jinja2' ([...]/env-3.9.2/lib/python3.9/site-packages/jinja2/__init__.py)
```

Signed-off-by: Robert Schwebel <r.schwebel@pengutronix.de>