### PR TITLE
pytest: initialize aiohttp_client with app, not with function

### DIFF
--- a/flamingo/pytest.py
+++ b/flamingo/pytest.py
@@ -2,6 +2,7 @@ from subprocess import check_output, CalledProcessError, STDOUT
 from tempfile import TemporaryDirectory
 import logging
 import os
+import asyncio
 
 from aiohttp.web import Application
 import pytest
@@ -109,6 +110,7 @@ class FlamingoServerBuildEnvironment(FlamingoBuildEnvironment):
         self.app = None
         self.server = None
         self.client = None
+        self.loop = asyncio.get_event_loop()
 
     def build(self, *args, **kwargs):
         pass
@@ -142,7 +144,7 @@ class FlamingoServerBuildEnvironment(FlamingoBuildEnvironment):
             return self.app
 
         self.setup()
-        self.client = await self._aiohttp_client(_create_app)
+        self.client = await self._aiohttp_client(_create_app(self.loop))
 
     async def shutdown_live_server(self, app=None):
         if self.server:


### PR DESCRIPTION
The aiohttp_client(app) call expects an Application, not a function that
sets up and returns an Application.

Without this patch, the code explodes with

.tox/python/lib/python3.9/site-packages/flamingo/pytest.py:145:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

__param = <function FlamingoServerBuildEnvironment.setup_live_server.<locals>._create_app at 0x7fa2fcc9b700>, server_kwargs = None, kwargs = {}

    async def go(
        __param: Union[Application, BaseTestServer],
        *,
        server_kwargs: Optional[Dict[str, Any]] = None,
        **kwargs: Any,
    ) -> TestClient:
        if isinstance(__param, Application):
            server_kwargs = server_kwargs or {}
            server = TestServer(__param, **server_kwargs)
            client = aiohttp_client_cls(server, **kwargs)
        elif isinstance(__param, BaseTestServer):
            client = aiohttp_client_cls(__param, **kwargs)
        else:
>           raise ValueError("Unknown argument type: %r" % type(__param))
E           ValueError: Unknown argument type: <class 'function'>

.tox/python/lib/python3.9/site-packages/pytest_aiohttp/plugin.py:163: ValueError

Signed-off-by: Robert Schwebel <r.schwebel@pengutronix.de>