### PR TITLE
packaging: Move release-workflow from tox to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,13 @@ server: test-site
 	cd test-site && \
 	make server
 
+sdist: env
+	. $(PYTHON_VENV)/bin/activate && \
+	rm -rf dist *.egg-info && \
+	./setup.py sdist
+
+_release: sdist
+	. $(PYTHON_VENV)/bin/activate && \
+	twine upload dist/*
+
 .PHONY: test-site

--- a/REQUIREMENTS.dev.txt
+++ b/REQUIREMENTS.dev.txt
@@ -1,2 +1,4 @@
 -e .[full]
 tox
+setuptools>=36.5.0
+twine

--- a/tox.ini
+++ b/tox.ini
@@ -29,15 +29,3 @@ deps =
 commands =
     flake8 flamingo tests
 
-
-[testenv:release]
-whitelist_externals = rm
-
-deps =
-    setuptools>=36.5.0
-    twine
-
-commands =
-    rm -rf dist build *.egg-info
-    ./setup.py sdist
-    twine upload --config-file ~/.pypirc.pengutronix dist/*


### PR DESCRIPTION
This changes the way pypi releases of this packages are made.
Until now sdists and uploads have been managed by tox.
With this change creating the sdist and uploading are managed by make
using the Makefile.
With this change we also split the sdist- and upload-step. This allows
some room for reviews of the created sdist.