### PR TITLE
plugin/feeds: Add support for podcast RSS feeds

### DIFF
--- a/doc/content/plugins/feeds.rst
+++ b/doc/content/plugins/feeds.rst
@@ -83,7 +83,12 @@ Usage
             # this callback is used to generate the 'updated' flag
             # of every feed entry
             'updated':
-                lambda content: content['date'].strftime('%Y-%m-%d %H:%M:%S+01:00')
+                lambda content: content['date'].strftime('%Y-%m-%d %H:%M:%S+01:00'),
+
+            # this callback is used to generate the 'published' flag
+            # of every feed entry
+            'published':
+                lambda content: content['date'].strftime('%Y-%m-%d %H:%M:%S+01:00'),
         },
     ]
 

--- a/doc/content/plugins/feeds.rst
+++ b/doc/content/plugins/feeds.rst
@@ -54,6 +54,8 @@ Usage
             'type': 'atom',  # [rss, atom]
             'output': 'feeds/atom.xml',
             'lang': 'en',
+            'description': 'Example Descriptions', # Only needed for RSS
+            'link': 'Link to the Feeds Website',   # Only needed for RSS
 
             # this callback is used to specify which contents should
             # be used to generate this feed

--- a/doc/content/plugins/feeds.rst
+++ b/doc/content/plugins/feeds.rst
@@ -54,8 +54,9 @@ Usage
             'type': 'atom',  # [rss, atom, podcast]
             'output': 'feeds/atom.xml',
             'lang': 'en',
-            'description': 'Example Descriptions', # Only needed for rss
-            'link': 'Link to the Feeds Website',   # Only needed for rss
+            'description': 'Example Descriptions', # Only needed for rss and podcast
+            'link': 'Link to the Feed itself',   # Only needed for rss and podcast
+            'link_alternate': 'Link to the Feeds Website',   # Only needed for rss and podcast
             'podcast_image': 'URL of an Image for the Podcast Feed', # Only for podcast
             'itunes_owner': {'name': 'Contact Name', 'email': 'email@example.com'}, # Only for podcast
             'itunes_category': [ # Only for Podcast

--- a/doc/content/plugins/feeds.rst
+++ b/doc/content/plugins/feeds.rst
@@ -51,11 +51,17 @@ Usage
         {
             'id': 'www.example.org',
             'title': 'Example.org feed',
-            'type': 'atom',  # [rss, atom]
+            'type': 'atom',  # [rss, atom, podcast]
             'output': 'feeds/atom.xml',
             'lang': 'en',
-            'description': 'Example Descriptions', # Only needed for RSS
-            'link': 'Link to the Feeds Website',   # Only needed for RSS
+            'description': 'Example Descriptions', # Only needed for rss
+            'link': 'Link to the Feeds Website',   # Only needed for rss
+            'podcast_image': 'URL of an Image for the Podcast Feed', # Only for podcast
+            'itunes_owner': {'name': 'Contact Name', 'email': 'email@example.com'}, # Only for podcast
+            'itunes_category': [ # Only for Podcast
+                {'cat': 'Technology'},
+            ], # A List of categories is here: https://podcasters.apple.com/support/1691-apple-podcasts-categories
+            'itunes_explicit': 'no', # Only for Podcast; one of ['yes', 'no', 'clean']
 
             # this callback is used to specify which contents should
             # be used to generate this feed
@@ -80,3 +86,14 @@ Usage
                 lambda content: content['date'].strftime('%Y-%m-%d %H:%M:%S+01:00')
         },
     ]
+
+
+For the feed type `podcast` every content returned by the `contents` -filter must contain a header
+field in the following format:
+
+.. code-block:: python
+
+    podcast:
+      url: http://url.to/file.mp3
+      size: 123456789   # in bytes
+      type: audio/mpeg  # optional, defaults to audio/mpeg

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -65,9 +65,13 @@ class Feeds:
 
                     if 'updated' in feed_config:
                         fe_updated = feed_config['updated'](i)
-
                     else:
                         fe_updated = ''
+
+                    if 'published' in feed_config:
+                        fe_published = feed_config['published'](i)
+                    else:
+                        fe_published = ''
 
                     if 'podcast' in i:
                         fe_podcast_url = i['podcast'].get('url', '')
@@ -90,6 +94,9 @@ class Feeds:
                     if not fe_updated:
                         missing_attributes.append('updated')
 
+                    if not fe_published:
+                        missing_attributes.append('published')
+
                     if feed_config['type'] == 'podcast':
                         if not fe_podcast_url:
                             missing_attributes.append('podcast->url')
@@ -107,6 +114,7 @@ class Feeds:
                     fe.id(fe_id)
                     fe.title(fe_title)
                     fe.updated(fe_updated)
+                    fe.published(fe_published)
                     fe.link(fe_link)
 
                     if i['content_body']:

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -24,6 +24,9 @@ class Feeds:
 
                 fg = FeedGenerator()
 
+                if 'lang' in feed_config:
+                    fg.language(feed_config['lang'])
+
                 fg.id(feed_config['id'])
                 fg.title(feed_config['title'])
 

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -99,6 +99,8 @@ class Feeds:
 
                 elif feed_config['type'] == 'rss':
                     content['content_body'] = fg.rss_str().decode()
+                else:
+                    raise ValueError(f'Unkown Feed type {feed_config["type"]}')
 
                 context.contents.add(**content)
 

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -34,6 +34,7 @@ class Feeds:
                 if feed_config['type'] in ['rss', 'podcast']:
                     fg.description(feed_config['description'])
                     fg.link(href=feed_config['link'], rel='self')
+                    fg.link(href=feed_config['link_alternate'], rel='alternate')
 
                 # setup podcast environment
                 if feed_config['type'] == 'podcast':

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -27,6 +27,11 @@ class Feeds:
                 fg.id(feed_config['id'])
                 fg.title(feed_config['title'])
 
+                # set parameters needed for rss-feeds
+                if feed_config['type'] == 'rss':
+                    fg.description(feed_config['description'])
+                    fg.link(href=feed_config['link'], rel='self')
+
                 for i in feed_config['contents'](context):
                     fe = fg.add_entry()
 


### PR DESCRIPTION
This PR adds support for RSS-feeds with some basic podcast extensions.

The fields added to the podcast-feed have been tested against the _Antennapod_ Podcatcher.
Maybe other apps / services need some more or other fields. If this turns out to be the case we can add them later on.

In order to make RSS-feeds working I also fixed RSS feeds as a whole by adding the  mandatory `description` and `link` fields.