### PR TITLE
plugins/sphinx_themes: expose docutils verison

### DIFF
--- a/flamingo/plugins/sphinx_themes/sphinx_theme.py
+++ b/flamingo/plugins/sphinx_themes/sphinx_theme.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import logging
 import shutil
 import os
+import docutils
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -188,6 +189,7 @@ class SphinxTheme:
             self._static_file_template_context_cache = {
                 **self.config.get_theme_options(),
             }
+            self._static_file_template_context_cache['docutils_version_info'] = docutils.__version_info__[:5]
 
         return deepcopy(self._static_file_template_context_cache)
 


### PR DESCRIPTION
Since Sphinx 5.0.2 the docutils version is exposed as a template variable by Sphinx. See:
https://github.com/sphinx-doc/sphinx/pull/10523/

In order to use Sphinx themes we need to do the same. This change exposes the version info in the same way as it's done in Sphinx.