### PR TITLE
plugin:tags: makes tags plugin understands yaml lists

### DIFF
--- a/flamingo/plugins/tags/tags.py
+++ b/flamingo/plugins/tags/tags.py
@@ -20,7 +20,11 @@ class Tags:
 
                 continue
 
-            content['tag_names'] = split(content['tags'])
+            if isinstance(content['tags'], list):
+                content['tag_names'] = content['tags']
+            else:
+                content['tag_names'] = split(content['tags'])
+
             content['tags'] = [slugify(i) for i in content['tag_names']]
 
         tags = sorted(list(set(sum(context.contents.values('tags'), []))))


### PR DESCRIPTION
Before you could specify tags only as list string:

  tags: tag1, tag_foo, tag4

Now you can write yaml lists instead:

  tags:
    - tag1
    - tag_foo - tag4