### PR TITLE
update feedgen dependency, define Atom feed summary type as HTML

### DIFF
--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -136,7 +136,7 @@ class Feeds:
                         summary = str(i['summary'])
                         if 'html_filter' in feed_config:
                             summary = feed_config['html_filter'](summary)
-                        fe.summary(summary)
+                        fe.summary(summary, type='html')
 
                     if feed_config['type'] == 'podcast':
                         fe.enclosure(fe_podcast_url, str(fe_podcast_size), fe_podcast_type)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ EXTRAS_REQUIRE = {
         'markdown',
     ],
     'feeds': [
-        'feedgen==0.7.0',
+        'feedgen==0.9.0',
     ],
     'thumbnails': [
         'pillow',


### PR DESCRIPTION
[feedgen 0.9.0](https://github.com/lkiesow/python-feedgen/releases/tag/v0.9.0) added support for HTML summaries for Atom feeds. So update feedgen 0.7.0 -> 0.9.0.

We've passed HTML content in summaries before. Now that feedgen allows us to specify the content type, let's stop confusing feed readers and define the summary as HTML.
