### PR TITLE
Context: Filter MarkupResemblesLocatorWarning from BeautifulSoup

### DIFF
--- a/flamingo/core/context.py
+++ b/flamingo/core/context.py
@@ -1,6 +1,9 @@
 import logging
 import shutil
 import os
+import warnings
+
+import bs4
 
 from flamingo.core.data_model import ContentSet, AND, NOT, OR, Q, F
 from flamingo.core.plugins.plugin_manager import PluginManager
@@ -33,6 +36,16 @@ class Context(OverlayObject):
         # setup logging
         self.logger = logging.getLogger('flamingo')
         self.logger.debug('setting up context')
+
+        # BS4: Filter MarkupResemblesLocatorWarning
+        # BS4 emits warnings when we try to parse strings that look like a
+        # path or url. So if we parse some content that may only contain
+        # something that looks like a path or url, but is a valid content,
+        # we would be greeted with a MarkupResemblesLocatorWarning.
+        warnings.filterwarnings(
+            "ignore",
+            category=bs4.MarkupResemblesLocatorWarning,
+        )
 
         # setup plugins
         self.plugins = PluginManager(self)


### PR DESCRIPTION
BeautifulSoup will raise a `MarkupResemblesLocatorWarning` every time it is asked to parse a string that looks like a path or url.

This warning is intended to aid novice users. But in the context of flamingo it leads to warning every time a content consists of something that looks like a path or url to bs4.

With this change we globally disable this specific warning from bs4. Disabling warning this early in the startup process makes this effective for flamingo itself and all plugins. (Settings are loaded earlier - but I hope nobody needs to run bs4 in their settings modules...)