### PR TITLE
plugins/Sphinx: Work around Sphinx using new config format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,22 @@
 Changelog
 =========
 
+`v1.10.1 <https://github.com/pengutronix/flamingo/compare/v1.10...v1.10.1>`_ (2024-04-23)
+-----------------------------------------------------------------------------------------
+
+Changes
+~~~~~~~
+
+(none)
+
+Bugfixes
+~~~~~~~~
+
+* plugins/Sphinx: Sphinx 7.3.0 has introduced a
+  `new configuration format <https://github.com/sphinx-doc/sphinx/pull/12265>`__ for themes.
+  This breaks the way we parse the theme configuration.
+  For this bugfix release we pin the Sphinx dependency to :code:`<7.3.0` to work around this problem.
+
 `v1.10 <https://github.com/pengutronix/flamingo/compare/v1.9...v1.10>`_ (2024-04-22)
 ------------------------------------------------------------------------------------
 

--- a/flamingo/__init__.py
+++ b/flamingo/__init__.py
@@ -5,7 +5,7 @@ from flamingo.core.plugins.plugin_manager import hook  # NOQA
 
 _dirname = os.path.dirname(__file__)
 
-VERSION = (1, 10)
+VERSION = (1, 10, 1)
 VERSION_STRING = '.'.join([str(i) for i in VERSION])
 THEME_ROOT = os.path.join(_dirname, 'theme')
 PROJECT_TEMPLATES_ROOT = os.path.join(_dirname, 'project_templates')

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ EXTRAS_REQUIRE = {
         'coloredlogs',
     ],
     'sphinx-themes': [
-        'sphinx>=4.5.0',
+        'sphinx>=4.5.0,<7.3.0',
         'sphinx_rtd_theme>=1.0.0',
     ],
 }


### PR DESCRIPTION
Since Sphinx 7.3.0 they use a new toml-based config format for the theme configuration. See:
https://github.com/sphinx-doc/sphinx/pull/12265

This breaks how the Flamingo Sphinx plugin handles the theme configuration.
With this change we pin Sphinx to a version <7.3.0 to work around this issue until we have a proper fix.

Also: Update changelog and bump version for a new release.