### PR TITLE
github-workflows: Bump Workflow Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,4 +36,4 @@ jobs:
     - name: Run tox
       run: tox -e py
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build
         run: git fetch -a && cd doc &&  make html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: doc/output/
 
@@ -46,5 +46,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
Our workflows start to issue deprecation warnings. See for example here: https://github.com/pengutronix/flamingo/actions/runs/8827878412

This change bumps the used workflows to the most recent mayor version.