### PR TITLE
plugins/feeds: mention summary plugin, render summaries correctly

### DIFF
--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -165,6 +165,9 @@ class Feeds:
                                 'name': author,
                             })
 
+                    # relies on a plugin generating a summary - see
+                    # https://github.com/pengutronix/flamingo-ptx-blog-engine/blob/master/flamingo_ptx_blog_engine/summary.py
+                    # for an example
                     if i['summary']:
                         summary = str(i['summary'])
                         if 'html_filter' in feed_config:

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -29,6 +29,8 @@ def make_urls_absolute(html, base_url):
 
 class Feeds:
     def pre_build(self, context):
+        env = context.templating_engine.env
+        render_summary = env.globals.get('render_summary')
         FEEDS_DOMAIN = getattr(context.settings, 'FEEDS_DOMAIN', '/')
         FEEDS = getattr(context.settings, 'FEEDS', [])
 
@@ -169,7 +171,13 @@ class Feeds:
                     # https://github.com/pengutronix/flamingo-ptx-blog-engine/blob/master/flamingo_ptx_blog_engine/summary.py
                     # for an example
                     if i['summary']:
-                        summary = str(i['summary'])
+                        if render_summary:
+                            summary = render_summary(i)
+                        else:
+                            summary = str(i['summary'])
+
+                        summary = make_urls_absolute(summary, fe_link['href'])
+
                         if 'html_filter' in feed_config:
                             summary = feed_config['html_filter'](summary)
                         fe.summary(summary, type='html')


### PR DESCRIPTION
Unrendered summaries contain directives such as:

```
{{ link('content/blog-post.html', 'foo') }}
```

These do not belong in the final HTML output. A function for summary rendering can be provided by a custom summary plugin. Use that if available and make rendered URLs absolute afterwards.

While at it, mention that summary functionality is only provided by a plugin. The summary plugin used by Pengutronix is publicly available in the flamingo-ptx-blog-engine repository [1]. It is not part of flamingo itself because it contains theme references (`ptx-image`, `ptx-sidebar`, `ps-gallery`).

[1] https://github.com/pengutronix/flamingo-ptx-blog-engine/blob/master/flamingo_ptx_blog_engine/summary.py