### PR TITLE
plugins/sphinx-themes: Fix dependency for Python >=3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ EXTRAS_REQUIRE = {
     'sphinx-themes': [
         'sphinx>=4.5.0,<7.3.0',
         'sphinx_rtd_theme>=1.0.0',
+        'setuptools',
     ],
 }
 


### PR DESCRIPTION
The sphinx-theme plugin uses `pkg_resources` to introspect Sphinx. In Python 3.12 `pkg_resources` is not available by default, because `setuptools` is not installed to a venv by default.

So starting with 3.12 the plugin is broken.

But `setuptools` still contains `pkg_resources`, so we can work around this issue for now by installing `setuptools` manually. Thus, this change adds this dependency for the `sphinx-themes` plugin.

This has been tested with Python 3.12 and 3.13 with `setuptools` up to 75.6.0.