### PR TITLE
plugins/redirects: Fix tabs are parsed as part of the source

### DIFF
--- a/flamingo/plugins/redirects.py
+++ b/flamingo/plugins/redirects.py
@@ -15,7 +15,7 @@ HTML_TEMPLATE = """
 
 class RedirectRulesParser(ContentParser):
     FILE_EXTENSIONS = ['rr']
-    RULE_RE = re.compile(r'^(?P<code>[0-9]+)(\s{1,})(?P<src>[^ ]+)(\s{1,})(?P<dst>[^ \n]+)$')  # NOQA
+    RULE_RE = re.compile(r'^(?P<code>[0-9]+)(\s{1,})(?P<src>[^\s]+)(\s{1,})(?P<dst>[^\s]+)$')  # NOQA
 
     def parse(self, file_content, content):
         content['output'] = '/dev/null'


### PR DESCRIPTION
Until now the columns of a `.rr`-files could only be separated by spaces.
This regularly leads to not working redirects, where the generated source-file would contain tabs as part of the file name.

This comes down to how the regex parses the file: Before this change only spaces were not part of source and destination - but other whitespace was ok.

With this change source and destination can not contain any whitespace. Thus tabs are parsed as separators - as one would expect.