### PR TITLE
plugins/rst: Allow to set margins on row-directive

### DIFF
--- a/flamingo/plugins/rst/bootstrap3.py
+++ b/flamingo/plugins/rst/bootstrap3.py
@@ -17,10 +17,19 @@ def _gen_directives(context):
             return nodes
 
     class BootstrapRow(NestedDirective):
+        option_spec = {
+            "margin-top": directives.unchanged,
+            "margin-bottom": directives.unchanged,
+        }
+
         def run(self):
             nodes = super().run(context)
 
-            nodes.insert(0, raw("", '<div class="row">', format="html"))
+            stylespec = []
+            for k, v in self.options.items():
+                if k in self.option_spec:
+                    stylespec.append(f"{k}: {v};")
+            nodes.insert(0, raw("", f'<div class="row" style="{" ".join(stylespec)}">', format="html"))
             nodes.append(raw("", "</div>", format="html"))
 
             return nodes


### PR DESCRIPTION
This allows to set per-instance margin-{top, bottom} styles for a bootstrap-row.
This may be used in rare situations where the defaults do not yield good results.