### PR TITLE
Fix doc build

### DIFF
--- a/doc/REQUIREMENTS.txt
+++ b/doc/REQUIREMENTS.txt
@@ -2,3 +2,4 @@
 beautifulsoup4
 sphinx_rtd_theme
 pygments>=2.12.0
+sphinx_rtd_theme<3

--- a/flamingo/plugins/__init__.py
+++ b/flamingo/plugins/__init__.py
@@ -1,11 +1,11 @@
-import contextlib
-
 from .authors.authors import Authors  # NOQA
 from .bootstrap.plugins import Bootstrap3, Bootstrap4  # NOQA
+from .feeds import Feeds  # NOQA
 from .git import Git  # NOQA
 from .html import HTML  # NOQA
 from .i18n import I18N  # NOQA
 from .jquery.plugins import jQuery1, jQuery2, jQuery3  # NOQA
+from .md import Markdown  # NOQA
 from .menu.menu import Menu  # NOQA
 from .photoswipe.plugin import PhotoSwipe  # NOQA
 from .redirects import Redirects  # NOQA
@@ -14,27 +14,11 @@ from .rst.image import rstImage  # NOQA
 from .rst.include import rstInclude  # NOQA
 from .rst.link import rstLink  # NOQA
 from .rst.plugin import reStructuredText  # NOQA
+from .rst.pygments import rstPygments  # NOQA
 from .rst.table import rstTable  # NOQA
 from .rtd.plugin import ReadTheDocs  # NOQA
+from .sphinx_themes.plugin import SphinxThemes  # NOQA
 from .tags.tags import Tags  # NOQA
+from .thumbnails import Thumbnails  # NOQA
 from .time import Time  # NOQA
 from .yaml import Yaml  # NOQA
-
-with contextlib.suppress(ImportError):
-    from .rst.pygments import rstPygments  # NOQA
-
-
-with contextlib.suppress(ImportError):
-    from .feeds import Feeds  # NOQA
-
-
-with contextlib.suppress(ImportError):
-    from .md import Markdown  # NOQA
-
-
-with contextlib.suppress(ImportError):
-    from .thumbnails import Thumbnails  # NOQA
-
-
-with contextlib.suppress(ImportError):
-    from .sphinx_themes.plugin import SphinxThemes  # NOQA

--- a/flamingo/plugins/sphinx_themes/sphinx_theme.py
+++ b/flamingo/plugins/sphinx_themes/sphinx_theme.py
@@ -3,11 +3,11 @@ import os
 import shutil
 from configparser import RawConfigParser
 from copy import deepcopy
+from importlib.metadata import entry_points
 
 import docutils
 import sphinx
 from jinja2 import Environment, FileSystemLoader
-from pkg_resources import iter_entry_points
 from sphinx.config import Config
 from sphinx.jinja2glue import _tobool, _todim, _toint
 from sphinx.registry import SphinxComponentRegistry
@@ -49,7 +49,7 @@ class SphinxApp:
             themes[name] = theme_path
 
         # discover 3rd party themes from pkg resources
-        for entry_point in iter_entry_points("sphinx.html_themes"):
+        for entry_point in entry_points(group="sphinx.html_themes"):
             name = entry_point.name
             module = entry_point.load()
             theme_path = os.path.dirname(module.__file__)


### PR DESCRIPTION
Fix the doc build by

 - Replacing the deprecated/removed `pkg_resources.iter_entry_points` with `importlib.metadata.entry_points`
 - Limiting `sphinx_rtd_theme` to v2

and don't suppress `ImportError` for plugins anymore. That was how we missed these issues in the first place.