### PR TITLE
Plugins/Redirects: Raise Errors Instead of Silently Swallowing Problems

### DIFF
--- a/flamingo/plugins/redirects.py
+++ b/flamingo/plugins/redirects.py
@@ -33,6 +33,11 @@ class RedirectRulesParser(ContentParser):
 
             match = match.groupdict()
 
+            if match["code"] != "302":
+                raise ParsingError(
+                    f"Invalid redirect rule code: {match['code']} in line: '{line}'. Only 302 is supported."
+                )
+
             content["rules"].append(
                 (
                     match["code"],

--- a/flamingo/plugins/redirects.py
+++ b/flamingo/plugins/redirects.py
@@ -1,6 +1,6 @@
 import re
 
-from flamingo.core.parser import ContentParser
+from flamingo.core.parser import ContentParser, ParsingError
 
 HTML_TEMPLATE = """
 <!DOCTYPE html>
@@ -29,7 +29,7 @@ class RedirectRulesParser(ContentParser):
             match = self.RULE_RE.search(line)
 
             if not match:
-                continue
+                raise ParsingError(f"Invalid redirect rule line: '{line}'")
 
             match = match.groupdict()
 

--- a/tests/test_plugin_Redirects.py
+++ b/tests/test_plugin_Redirects.py
@@ -46,3 +46,23 @@ def test_redirects_broken_line(flamingo_env, caplog: pytest.LogCaptureFixture):
     assert any("Invalid redirect rule line: '302a /foo.html /bar.html'" in line for line in caplog.messages)
 
     assert not flamingo_env.exists("/output/foo.html")
+
+
+def test_redirects_supported_codes(flamingo_env, caplog: pytest.LogCaptureFixture):
+    flamingo_env.settings.PLUGINS = ["flamingo.plugins.Redirects"]
+
+    flamingo_env.write(
+        "/content/redirects.rr",
+        """
+    999 /foo.html /bar.html
+    """,
+    )
+
+    caplog.set_level(logging.ERROR)
+    flamingo_env.build()
+    assert any(
+        "Invalid redirect rule code: 999 in line: '999 /foo.html /bar.html'. Only 302 is supported." in line
+        for line in caplog.messages
+    )
+
+    assert not flamingo_env.exists("/output/foo.html")

--- a/tests/test_plugin_Redirects.py
+++ b/tests/test_plugin_Redirects.py
@@ -1,3 +1,8 @@
+import logging
+
+import pytest
+
+
 def test_Redirects(flamingo_env):
     from bs4 import BeautifulSoup
 
@@ -24,3 +29,20 @@ def test_Redirects(flamingo_env):
             "http-equiv": "refresh",
         },
     )
+
+
+def test_redirects_broken_line(flamingo_env, caplog: pytest.LogCaptureFixture):
+    flamingo_env.settings.PLUGINS = ["flamingo.plugins.Redirects"]
+
+    flamingo_env.write(
+        "/content/redirects.rr",
+        """
+    302a /foo.html /bar.html
+    """,
+    )
+
+    caplog.set_level(logging.ERROR)
+    flamingo_env.build()
+    assert any("Invalid redirect rule line: '302a /foo.html /bar.html'" in line for line in caplog.messages)
+
+    assert not flamingo_env.exists("/output/foo.html")


### PR DESCRIPTION
While exploring the `Redirects` plugin I found that we silently drop lines that we can not parse. This is not good practice as it may hide problems with the input data from the user.

While I am on it: Also add another check to make sure that the user only uses HTTP Status Codes we actually support.