### PR TITLE
Actions: Drop Publishing to test.pypi.org

### DIFF
--- a/.github/workflows/check-and-publish.yaml
+++ b/.github/workflows/check-and-publish.yaml
@@ -43,28 +43,6 @@ jobs:
           name: dist
           path: dist
 
-  publish-test:
-    name: Publish to test.pypi.org
-    if: ${{ github.event_name == 'push' && vars.PUBLISH_PYPI == 'true' && (startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
-    runs-on: ubuntu-latest
-    needs:
-      - codespell
-      - pytest
-      - ruff
-      - build
-    permissions:
-      id-token: write
-    steps:
-      - name: Download artifacts from build stage
-        uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist/
-      - name: Publish distribution package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish-production:
     name: Publish
     if: ${{ github.event_name == 'push' && vars.PUBLISH_PYPI == 'true' && startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/check-and-publish.yaml
+++ b/.github/workflows/check-and-publish.yaml
@@ -57,7 +57,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts from build stage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build
         run: git fetch -a && cd doc &&  make html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: doc/output/
 
@@ -46,5 +46,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 


### PR DESCRIPTION
We initially intended to publish every commit / merge to master to test.pypi.org to exercise publishing releases.

It turns out: `flamingo` on test.pypi.org is already taken by another org. So we can not publish to that name. But publishing to a different name would mean to already build the package with a different name. That actually sounds like more pain than it is worth, so we drop this step entirely.