### PR TITLE
plugins: reStructuredText: fix heading levels of parsed documents

### DIFF
--- a/flamingo/plugins/rst/parser.py
+++ b/flamingo/plugins/rst/parser.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from docutils.core import publish_parts
-from docutils.nodes import title
+from docutils.nodes import section, title
 from docutils.utils import SystemMessage
 from docutils.writers.html4css1 import Writer
 
@@ -129,17 +129,33 @@ class FlamingoWriter(Writer):
                 if isinstance(node, title):
                     tree.children.remove(node)
 
-                    return node
+                    return tree, node
 
-                html_title = _get_content_title(node)
+                result = _get_content_title(node)
 
-                if html_title:
-                    return html_title
+                if result:
+                    return result
 
-        content_title = _get_content_title(document)
+        result = _get_content_title(document)
 
-        if content_title:
-            return content_title[0].astext()
+        if not result:
+            return
+
+        parent, content_title = result
+
+        # The content title gets rendered as <h1> by the theme, but the
+        # section it was taken from remains part of the document. When it is
+        # the only top level section, all remaining headings are nested one
+        # level deeper than they appear and would start at <h3>, skipping
+        # <h2>. Decrementing the initial header level compensates for that.
+        top_level_sections = [node for node in document.children if isinstance(node, section)]
+        if [parent] == top_level_sections:
+            initial_header_level = document.settings.initial_header_level
+
+            if str(initial_header_level).isdigit():
+                document.settings.initial_header_level = max(int(initial_header_level) - 1, 1)
+
+        return content_title[0].astext()
 
     def write(self, document, destination):
         if not self.flamingo_doctitle_xform:

--- a/tests/test_core_parser_rst.py
+++ b/tests/test_core_parser_rst.py
@@ -25,6 +25,44 @@ foobar"""
     assert content_body == '<divclass="section"id="bar">foobar</div>'
 
 
+def test_rst_header_levels(flamingo_dummy_context):
+    from flamingo import Content
+    from flamingo.plugins.rst.plugin import RSTParser
+
+    raw_content = """
+title: foo
+
+
+Document Title
+==============
+
+intro
+
+Section
+-------
+
+text
+
+Sub Section
+~~~~~~~~~~~
+
+more text"""
+
+    parser = RSTParser(flamingo_dummy_context)
+    content = Content()
+
+    parser.parse(raw_content, content)
+
+    content_body = content["content_body"]
+
+    # the content title gets rendered as <h1>, so the headings in the
+    # content body have to start at <h2>
+    assert content["content_title"] == "Document Title"
+    assert "<h1" not in content_body
+    assert "<h2>Section</h2>" in content_body
+    assert "<h3>Sub Section</h3>" in content_body
+
+
 def test_error_line_number(flamingo_dummy_context):
     import pytest
 


### PR DESCRIPTION
For documents that have only a lone top-level section and one or more second level sections like:

    Title
    #####
  
    Subtitle 1
    ==========
  
    Subtitle 2
    ==========

, the generated HTML document lacks the `<h2>` heading level:

    <h1>Title</h1>
    ...
    <h3>Subtitle 1</h1>
    ...
    <h3>Subtitle 2</h1>

This was introduced with the changes from d0880d30 ("plugins: reStructuredText: parser: disable document_xform by default").

With `doctitle_xform` disabled, `FlamingoWriter` takes the title of the document out of the docutils document tree and exposes it as 'content_title', but leaves the section it belongs to in place. Since `initial_header_level` is 2, every heading inside of that now headless section got rendered one level too deep:
themes render 'content_title' as `<h1>`,
the headings of the document started at `<h3>`,
and `<h2>` was never used.

Decrement the initial header level when the content title was taken from the only top level section of the document, so the headings of the document start at `<h2>` again.
