### PR TITLE
server: logging: fix ruff check finding fix

### DIFF
--- a/flamingo/server/logging.py
+++ b/flamingo/server/logging.py
@@ -52,15 +52,14 @@ class RPCHandler(logging.Handler):
         if self.internal_level and record.levelno < self.internal_level:
             return
 
-        # filter exceptions that flamingo server handles itself
-        if (
-            record.exc_info
-            and isinstance(record.exc_info[1], OSError)
-            and record.exc_info[1].errno in (13, 98)
-            or isinstance(record.exc_info[1], RuntimeError)
-            and record.exc_info[1].args[0] == "Event loop is closed"
-        ):
-            return
+        # filter exceptions that flamingo server handles it self
+        if record.exc_info:
+            # OSErrors
+            if isinstance(record.exc_info[1], OSError) and record.exc_info[1].errno in (13, 98):
+                return
+
+            if isinstance(record.exc_info[1], RuntimeError) and record.exc_info[1].args[0] == "Event loop is closed":
+                return
 
         # add record to ring buffer
         time_stamp = datetime.fromtimestamp(record.created)


### PR DESCRIPTION
The original fix 80791370 attempted to fix the following 'ruff check' error:

```
  SIM102 Use a single `if` statement instead of nested `if` statements
    --> flamingo/server/logging.py:56:9
     |
  55 |           # filter exceptions that flamingo server handles it self
  56 | /         if record.exc_info:
  57 | |             # OSErrors
  58 | |             if isinstance(record.exc_info[1], OSError) and record.exc_info[1].errno in (13, 98) or isinstance(record.exc_info[1], RuntimeError) and record.exc_info[1].args[0] == "Event loop is closed":
     | |_________________________________________________________________________________________________________________________________________________________________________________________________________^
  59 |                   return
     |
  help: Combine `if` statements using `and`
```

Unfortunately, it combined the outer 'if' with the inner 'if' by just prepending the condition with 'and'.
Since 'and' binds tighter than 'or', the guard only applies to the OSError branch, and the RuntimeError branch subscripts 'record.exc_info' unconditionally. Every log record without exception info raises

    TypeError: 'NoneType' object is not subscriptable

Restore the guard and split the filter into one check per exception type.

This also silences the ruff check error.

Fixes: 80791370 ("Ruff: Fix ruff check findings")