### PR TITLE
GitHub Actions: Fix check-and-publish

### DIFF
--- a/.github/workflows/check-and-publish.yaml
+++ b/.github/workflows/check-and-publish.yaml
@@ -52,7 +52,6 @@ jobs:
       - pytest
       - ruff
       - build
-      - publish-test
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Workflow `publish-production` depends on a workflow `publish-test` that has been dropped in 2030ec2d98c07ae4a9560d1bc39bea7bb3290b0a.

Drop the dependency to fix the workflow.

Fixes 2030ec2d98c07ae4a9560d1bc39bea7bb3290b0a.

Should fix broken workflows like this one: https://github.com/pengutronix/flamingo/actions/runs/30612706410