### PR TITLE
Plugins: Do not fail on missing optional dependencies

### DIFF
--- a/flamingo/core/plugins/plugin_manager.py
+++ b/flamingo/core/plugins/plugin_manager.py
@@ -1,8 +1,14 @@
 import logging
+import sys
 
 from flamingo.core.utils.imports import acquire
 
 logger = logging.getLogger("flamingo.core.PluginManager")
+
+
+class PluginDependencyError(Exception):
+    pass
+
 
 HOOK_NAMES = [
     "setup",
@@ -107,6 +113,7 @@ class PluginManager:
 
             except Exception:
                 logger.error("setup of '%s' failed", plugin, exc_info=True)
+                sys.exit(1)
 
         self._discover(HOOK_NAMES)
 

--- a/flamingo/plugins/feeds.py
+++ b/flamingo/plugins/feeds.py
@@ -2,7 +2,13 @@ import logging
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
-from feedgen.feed import FeedGenerator
+
+from flamingo.core.plugins.plugin_manager import PluginDependencyError
+
+try:
+    from feedgen.feed import FeedGenerator
+except ImportError:
+    FeedGenerator = None
 
 logger = logging.getLogger("flamingo.plugins.Feeds")
 
@@ -28,6 +34,10 @@ def make_urls_absolute(html, base_url):
 
 
 class Feeds:
+    def __init__(self):
+        if not FeedGenerator:
+            raise PluginDependencyError("Feeds plugin is missing optional installation dependency flamingo[feeds].")
+
     def pre_build(self, context):
         env = context.templating_engine.env
         render_summary = env.globals.get("render_summary")

--- a/flamingo/plugins/md.py
+++ b/flamingo/plugins/md.py
@@ -1,4 +1,9 @@
-import markdown
+from flamingo.core.plugins.plugin_manager import PluginDependencyError
+
+try:
+    import markdown
+except ImportError:
+    markdown = None
 from bs4 import BeautifulSoup
 
 from flamingo.core.parser import ContentParser
@@ -30,5 +35,11 @@ class MarkdownParser(ContentParser):
 
 
 class Markdown:
+    def __init__(self):
+        if not markdown:
+            raise PluginDependencyError(
+                "Markdown plugin is missing optional installation dependency flamingo[markdown]."
+            )
+
     def parser_setup(self, context):
         context.parser.add_parser(MarkdownParser(context))

--- a/flamingo/plugins/photoswipe/plugin.py
+++ b/flamingo/plugins/photoswipe/plugin.py
@@ -1,7 +1,20 @@
 import os
 
+from flamingo.core.plugins.plugin_manager import PluginDependencyError
+
+try:
+    import PIL
+except ImportError:
+    PIL = None
+
 
 class PhotoSwipe:
+    def __init__(self):
+        if not PIL:
+            raise PluginDependencyError(
+                "PhotoSwipe plugin is missing optional installation dependency flamingo[photoswipe]."
+            )
+
     THEME_PATHS = [
         os.path.join(os.path.dirname(__file__), "theme"),
     ]

--- a/flamingo/plugins/rst/pygments.py
+++ b/flamingo/plugins/rst/pygments.py
@@ -3,12 +3,26 @@ from tempfile import TemporaryDirectory
 
 from docutils.nodes import raw
 from docutils.parsers.rst import Directive, directives
-from pygments import highlight
-from pygments.formatters import HtmlFormatter
-from pygments.lexers import get_lexer_by_name, guess_lexer
-from pygments.styles import get_all_styles, get_style_by_name
-from pygments.token import Token
-from pygments.util import ClassNotFound
+
+from flamingo.core.plugins.plugin_manager import PluginDependencyError
+
+try:
+    from pygments import highlight
+    from pygments.formatters import HtmlFormatter
+    from pygments.lexers import get_lexer_by_name, guess_lexer
+    from pygments.styles import get_all_styles, get_style_by_name
+    from pygments.token import Token
+    from pygments.util import ClassNotFound
+except ImportError:
+    pygments = None
+    highlight = None
+    HtmlFormatter = None
+    get_lexer_by_name = None
+    guess_lexer = None
+    get_all_styles = None
+    get_style_by_name = None
+    Token = None
+    ClassNotFound = None
 
 from flamingo.plugins.rst import register_directive
 
@@ -70,6 +84,12 @@ def code_block(context):
 
 
 class rstPygments:
+    def __init__(self):
+        if not ClassNotFound:
+            raise PluginDependencyError(
+                "Pygments plugin is missing optional installation dependency flamingo[pygments]."
+            )
+
     def get_options(self):
         options = [
             (

--- a/flamingo/plugins/sphinx_themes/plugin.py
+++ b/flamingo/plugins/sphinx_themes/plugin.py
@@ -6,14 +6,25 @@ from tempfile import TemporaryDirectory
 
 from bs4 import BeautifulSoup
 from jinja2 import pass_context
-from sphinx import version_info as sphinx_version_info
-from sphinx.jinja2glue import _tobool, _todim, _toint, accesskey
 
 from flamingo import Content
 from flamingo.plugins.menu.menu import Section
 
+from ...core.plugins.plugin_manager import PluginDependencyError
 from . import defaults
-from .sphinx_theme import SphinxTheme
+
+try:
+    from sphinx import version_info as sphinx_version_info
+    from sphinx.jinja2glue import _tobool, _todim, _toint, accesskey
+
+    from .sphinx_theme import SphinxTheme
+except ImportError:
+    sphinx_version_info = None
+    _tobool = None
+    _todim = None
+    _toint = None
+    accesskey = None
+    SphinxTheme = None
 
 logger = logging.getLogger("flamingo.plugins.SphinxThemes")
 
@@ -50,6 +61,12 @@ class TocTree:
 
 
 class SphinxThemes:
+    def __init__(self):
+        if not SphinxTheme:
+            raise PluginDependencyError(
+                "SphinxThemes plugin is missing optional installation dependency flamingo[sphinx-themes]."
+            )
+
     # plugin options ##########################################################
     def reset_options(self):
         self.settings = {}

--- a/flamingo/plugins/thumbnails.py
+++ b/flamingo/plugins/thumbnails.py
@@ -4,16 +4,23 @@ import os
 import re
 from collections import OrderedDict
 
+from flamingo.core.plugins.plugin_manager import PluginDependencyError
+
 try:
     from docutils.parsers.rst import directives
 
     RST = True
 
 except ImportError:
+    directives = False
     RST = False
 
-from PIL import Image as PillowImage
-from PIL import UnidentifiedImageError
+try:
+    from PIL import Image as PillowImage
+    from PIL import UnidentifiedImageError
+except ImportError:
+    PillowImage = None
+    UnidentifiedImageError = None
 
 from flamingo.core.data_model import Content
 
@@ -86,6 +93,12 @@ def scale_image(original_size, width=None, height=None):
 
 class Thumbnails:
     THEME_PATHS = [os.path.join(os.path.dirname(__file__), "theme")]
+
+    def __init__(self):
+        if not UnidentifiedImageError:
+            raise PluginDependencyError(
+                "Thumbnails plugin is missing optional installation dependency flamingo[thumbnails]."
+            )
 
     def settings_setup(self, context):
         THUMBNAIL_CACHE = getattr(context.settings, "THUMBNAIL_CACHE", DEFAULT_THUMBNAIL_CACHE)


### PR DESCRIPTION
Flamingo has a set of optional dependencies defined in `pyproject.toml`. In 92643515b355828d3c548ead49949c38bf7d3552 the plugin system was altered in a way that loading any plugin will fail, if not all optional dependencies were present, eg. by not installing flamingo using `flamingo[full]`.
This leads to a situation where projects without `full` can not be built anymore.

Instead of suppressing the import error (like before 92643515b355828d3c548ead49949c38bf7d3552), plugins with optional dependencies will now fail gracefully, if their dependencies are not met: These plugins will will now raise `PluginDependencyError()` including a useful error message if they are loaded but their dependencies are not met.

Also, this change let's flamingo quit non-zero if any plugin configured in the project settings can not be loaded.